### PR TITLE
fix(sparql): keep welcome view rows on one line and make the connection status legible

### DIFF
--- a/src/utilities/uri.test.ts
+++ b/src/utilities/uri.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toJsonId, getIriFromNodeId, getLocalPartAndQuery, toDisplayPath, getFileName, getPath } from '@src/utilities/uri';
+import { toJsonId, getIriFromNodeId, getLocalPartAndQuery, toDisplayPath, getFileName, getPath, getFolderPath, shortenPathStart } from '@src/utilities/uri';
 
 describe('toJsonId', () => {
 	it('converts http URI to dot-separated identifier', () => {
@@ -148,5 +148,61 @@ describe('getPath', () => {
 
 	it('leaves an already-decoded native path unchanged', () => {
 		expect(getPath('/home/user/my project/models/thing.ttl')).toBe('/home/user/my project/models');
+	});
+});
+
+describe('getFolderPath', () => {
+	it('returns the folder part of a workspace URI', () => {
+		expect(getFolderPath('workspace:///queries/dbpedia/cities.rq')).toBe('queries/dbpedia');
+	});
+
+	it('returns an empty string when the URI has no folder part', () => {
+		expect(getFolderPath('census.rq')).toBe('');
+	});
+
+	it('returns an empty string for a file at the workspace root', () => {
+		expect(getFolderPath('workspace:///census.rq')).toBe('');
+	});
+
+	it('decodes percent-encoded folder segments', () => {
+		expect(getFolderPath('workspace:///my%20shapes/sub%20dir/file.ttl')).toBe('my shapes/sub dir');
+	});
+
+	it('does not decode twice, so a literal percent escape survives', () => {
+		expect(getFolderPath('workspace:///100%25%20done/file.ttl')).toBe('100% done');
+	});
+});
+
+describe('shortenPathStart', () => {
+	it('returns the path unchanged when it fits the budget', () => {
+		expect(shortenPathStart('queries/dbpedia', 40)).toBe('queries/dbpedia');
+	});
+
+	it('drops leading segments and marks them with an ellipsis', () => {
+		expect(shortenPathStart('mentor-rdf/src/rdf/tests/cases/sparql', 20)).toBe('…/tests/cases/sparql');
+	});
+
+	it('drops only as many leading segments as necessary', () => {
+		expect(shortenPathStart('mentor-rdf/src/rdf/tests/cases/sparql', 30)).toBe('…/src/rdf/tests/cases/sparql');
+	});
+
+	it('truncates mid-segment when the last segment alone exceeds the budget', () => {
+		expect(shortenPathStart('a/very-long-single-folder-name', 10)).toBe('…lder-name');
+	});
+
+	it('never exceeds the budget', () => {
+		const path = 'mentor-rdf/src/rdf/tests/cases/sparql/deeply/nested';
+
+		for (let maxLength = 1; maxLength <= path.length; maxLength++) {
+			expect(shortenPathStart(path, maxLength).length).toBeLessThanOrEqual(maxLength);
+		}
+	});
+
+	it('returns an empty string for a non-positive budget', () => {
+		expect(shortenPathStart('queries/dbpedia', 0)).toBe('');
+	});
+
+	it('returns an empty string unchanged', () => {
+		expect(shortenPathStart('', 40)).toBe('');
 	});
 });

--- a/src/utilities/uri.ts
+++ b/src/utilities/uri.ts
@@ -90,3 +90,56 @@ export function getPath(uri: string): string {
 		return uri;
 	}
 }
+/**
+ * Get the folder part of a URI string, without the trailing file name.
+ *
+ * Unlike {@link getPath}, a URI that consists of a file name only yields an empty
+ * string rather than the input, so callers can distinguish "no folder" from "a folder
+ * that happens to be named like a file".
+ * @param uri A URI string.
+ * @returns The decoded folder path, or an empty string if the URI has no folder part.
+ */
+export function getFolderPath(uri: string): string {
+	const parts = toDisplayPath(uri).split('/');
+
+	return parts.length > 1 ? parts.slice(0, -1).join('/') : '';
+}
+
+/**
+ * The marker standing in for the path segments omitted by {@link shortenPathStart}.
+ */
+const PATH_ELLIPSIS = '…';
+
+/**
+ * Shorten a display path from the start, so that its trailing and most specific segments
+ * stay readable inside a width-constrained list column.
+ *
+ * Leading segments are dropped whole and replaced by an ellipsis. Only when the last
+ * segment alone still exceeds the budget is it truncated mid-segment.
+ * @param path A display path, such as the result of {@link toDisplayPath}.
+ * @param maxLength The maximum number of characters of the returned string.
+ * @returns The path unchanged if it fits, otherwise an ellipsis-prefixed tail of it.
+ */
+export function shortenPathStart(path: string, maxLength: number): string {
+	if (maxLength <= 0) {
+		return '';
+	}
+
+	if (path.length <= maxLength) {
+		return path;
+	}
+
+	const segments = path.split('/').filter(segment => segment.length > 0);
+
+	for (let index = 1; index < segments.length; index++) {
+		const tail = `${PATH_ELLIPSIS}/${segments.slice(index).join('/')}`;
+
+		if (tail.length <= maxLength) {
+			return tail;
+		}
+	}
+
+	const lastSegment = segments[segments.length - 1] ?? path;
+
+	return PATH_ELLIPSIS + lastSegment.slice(lastSegment.length - (maxLength - PATH_ELLIPSIS.length));
+}

--- a/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
@@ -113,7 +113,7 @@ export function SparqlConnectionsList() {
 	};
 
 	return (
-		<div className="column column-wide">
+		<div className="column column-auto">
 			<div className="header">
 				<h3>Connections</h3>
 				<vscode-toolbar-button onClick={handleManageConnections}>

--- a/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
@@ -13,6 +13,38 @@ interface TestResult {
 }
 
 /**
+ * Get the status modifier class for a connection's leading icon, tinting it green or red to
+ * report the outcome of the last endpoint test.
+ * @param testResult The outcome of the last endpoint test, if the connection was tested.
+ * @returns A space-prefixed class name to append, or an empty string for an untested connection.
+ */
+function getConnectionStatusClass(testResult: TestResult | undefined): string {
+	if (testResult === undefined) {
+		return '';
+	}
+
+	return testResult.success ? ' connection-status-pass' : ' connection-status-error';
+}
+
+/**
+ * Get the tooltip of a connection's leading icon. A failed test reports its error here, so
+ * the message stays reachable from the tinted icon itself.
+ * @param testResult The outcome of the last endpoint test, if the connection was tested.
+ * @returns The outcome of the test, or `undefined` for an untested connection.
+ */
+function getConnectionStatusTooltip(testResult: TestResult | undefined): string | undefined {
+	if (testResult === undefined) {
+		return undefined;
+	}
+
+	if (testResult.success) {
+		return 'Connection test succeeded';
+	}
+
+	return testResult.error ? `Connection test failed: ${testResult.error}` : 'Connection test failed';
+}
+
+/**
  * The Connections column of the SPARQL results welcome view: lists all
  * connections in the query-history look, with a leading new-query button,
  * the cached graph count as details text and test / list-graphs context
@@ -134,8 +166,8 @@ export function SparqlConnectionsList() {
 							{testing[connection.id] ?
 								<span className="codicon codicon-sync codicon-modifier-spin" title="Testing connection..."></span> :
 								<span
-									className={`codicon codicon-arrow-swap${testResult?.success ? ' connection-status-pass' : ''}`}
-									title={testResult?.success ? 'Connection test succeeded' : undefined}
+									className={`codicon codicon-arrow-swap${getConnectionStatusClass(testResult)}`}
+									title={getConnectionStatusTooltip(testResult)}
 								></span>
 							}
 							<a className="file-link" title={`${connection.endpointUrl} — Edit connection settings`} onClick={() => handleEditConnection(connection)}>
@@ -145,9 +177,6 @@ export function SparqlConnectionsList() {
 								<span className={`folder muted${details.error ? ' connection-status-error' : ''}`} title={details.title}>
 									{details.text}
 								</span>
-							)}
-							{testResult?.success === false && (
-								<span className="codicon codicon-error connection-status-error" title={testResult.error}></span>
 							)}
 							<span className="actions">
 								<a className="execute-button codicon codicon-play" role="button" title="New query on this connection"

--- a/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { Fragment, useState, useEffect, useCallback } from 'react';
 import { useWebviewMessaging } from '@src/views/webviews/hooks';
 import { SparqlConnection } from '@src/languages/sparql/services/sparql-connection';
 import { SparqlConnectionGraphStatus, SparqlResultsWebviewMessages } from '../sparql-results-messages';
@@ -10,6 +10,38 @@ import { SparqlConnectionGraphStatus, SparqlResultsWebviewMessages } from '../sp
 interface TestResult {
 	success: boolean;
 	error?: string;
+}
+
+/**
+ * The graph-loading details of a connection: its loading state, the last load error or the
+ * number of graphs cached for it.
+ */
+interface GraphDetails {
+	/**
+	 * The visible summary text.
+	 */
+	text: string;
+
+	/**
+	 * The full message, shown as a tooltip when {@link text} only summarises it.
+	 */
+	title?: string;
+
+	/**
+	 * Whether the details report a failure and should be rendered in the error colour.
+	 */
+	error?: boolean;
+}
+
+/**
+ * One segment of a row's details text. Segments are rendered in order, separated by a
+ * middle dot.
+ */
+interface DetailSegment extends GraphDetails {
+	/**
+	 * Stable React key of the segment.
+	 */
+	key: string;
 }
 
 /**
@@ -45,11 +77,49 @@ function getConnectionStatusTooltip(testResult: TestResult | undefined): string 
 }
 
 /**
+ * Get the label reporting the outcome of a connection's last endpoint test, shown ahead of
+ * the graph count in the row's details text.
+ * @param testResult The outcome of the last endpoint test, if the connection was tested.
+ * @returns The status label, or `undefined` for an untested connection.
+ */
+function getConnectionStatusLabel(testResult: TestResult | undefined): string | undefined {
+	if (testResult === undefined) {
+		return undefined;
+	}
+
+	return testResult.success ? 'Connected' : 'Connection failed';
+}
+
+/**
+ * Get the details segments of a connection row, in display order: the outcome of the last
+ * endpoint test, followed by its graph-loading state, load error or cached graph count.
+ * @param testResult The outcome of the last endpoint test, if the connection was tested.
+ * @param graphDetails The graph-loading details of the connection, if any are known.
+ * @returns The segments to render, which may be empty for an untested connection whose
+ * graphs have never been listed.
+ */
+function getDetailSegments(testResult: TestResult | undefined, graphDetails: GraphDetails | undefined): DetailSegment[] {
+	const segments: DetailSegment[] = [];
+	const statusLabel = getConnectionStatusLabel(testResult);
+
+	if (statusLabel !== undefined) {
+		segments.push({ key: 'status', text: statusLabel, title: getConnectionStatusTooltip(testResult) });
+	}
+
+	if (graphDetails !== undefined) {
+		segments.push({ key: 'graphs', ...graphDetails });
+	}
+
+	return segments;
+}
+
+/**
  * The Connections column of the SPARQL results welcome view: lists all
- * connections in the query-history look, with a leading new-query button,
- * the cached graph count as details text and test / list-graphs context
- * buttons per row. The header offers a Manage button that opens the
- * Query > Connections settings section.
+ * connections in the query-history look. Each row leads with a connection icon
+ * tinted by the outcome of its last endpoint test, and carries that outcome and
+ * the cached graph count as dot-separated details text, followed by new-query /
+ * test / list-graphs context buttons. The header offers a Manage button that
+ * opens the Query > Connections settings section.
  */
 export function SparqlConnectionsList() {
 	const [connections, setConnections] = useState<SparqlConnection[]>([]);
@@ -126,7 +196,7 @@ export function SparqlConnectionsList() {
 	 * The details text of a row: the graph-loading state, the last load error or
 	 * the cached graph count, mirroring the settings list's graph badge.
 	 */
-	const getDetails = (connection: SparqlConnection): { text: string; title?: string; error?: boolean } | undefined => {
+	const getDetails = (connection: SparqlConnection): GraphDetails | undefined => {
 		if (loading[connection.id]) {
 			return { text: 'Loading…' };
 		}
@@ -158,8 +228,8 @@ export function SparqlConnectionsList() {
 			<div className="body button-list">
 				{connections.length === 0 && <span className="muted">No connections configured.</span>}
 				{connections.map(connection => {
-					const details = getDetails(connection);
 					const testResult = testResults[connection.id];
+					const segments = getDetailSegments(testResult, getDetails(connection));
 
 					return (
 						<div key={connection.id} className="history-item">
@@ -173,9 +243,16 @@ export function SparqlConnectionsList() {
 							<a className="file-link" title={`${connection.endpointUrl} — Edit connection settings`} onClick={() => handleEditConnection(connection)}>
 								<span>{connection.endpointUrl}</span>
 							</a>
-							{details && (
-								<span className={`folder muted${details.error ? ' connection-status-error' : ''}`} title={details.title}>
-									{details.text}
+							{segments.length > 0 && (
+								<span className="folder muted">
+									{segments.map((segment, index) => (
+										<Fragment key={segment.key}>
+											{index > 0 && <span className="detail-separator" aria-hidden="true">{' · '}</span>}
+											<span className={segment.error ? 'connection-status-error' : undefined} title={segment.title}>
+												{segment.text}
+											</span>
+										</Fragment>
+									))}
 								</span>
 							)}
 							<span className="actions">

--- a/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-connections-list.tsx
@@ -138,7 +138,7 @@ export function SparqlConnectionsList() {
 									title={testResult?.success ? 'Connection test succeeded' : undefined}
 								></span>
 							}
-							<a className="file-link" title="Edit connection settings" onClick={() => handleEditConnection(connection)}>
+							<a className="file-link" title={`${connection.endpointUrl} — Edit connection settings`} onClick={() => handleEditConnection(connection)}>
 								<span>{connection.endpointUrl}</span>
 							</a>
 							{details && (

--- a/src/views/webviews/views/sparql-results/components/sparql-recent-query-list.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-recent-query-list.tsx
@@ -110,7 +110,7 @@ export function SparqlRecentQueryList() {
 	};
 
 	return (
-		<div className="column column-wide">
+		<div className="column column-grow">
 			<div className="header">
 				<h3>Recent Queries</h3>
 				<vscode-toolbar-button onClick={handleSelectSparqlQueryFile}>

--- a/src/views/webviews/views/sparql-results/components/sparql-recent-query-list.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-recent-query-list.tsx
@@ -1,10 +1,54 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useWebviewMessaging } from '@src/views/webviews/hooks';
 import { SparqlQueryExecutionState, getDisplayName } from '@src/languages/sparql/services/sparql-query-state';
-import { toDisplayPath, getPath } from '@src/utilities/uri';
+import { getFolderPath, shortenPathStart } from '@src/utilities/uri';
 import { SparqlResultsWebviewMessages } from '../sparql-results-messages';
 import sparqlFileIconDark from '../../../../../../media/icons/dark/sparql-file.svg';
 import sparqlFileIconLight from '../../../../../../media/icons/light/sparql-file.svg';
+
+/**
+ * Maximum number of characters of the shortened workspace path shown beside a query's file
+ * name. Deeper paths are shortened from the start; the column's CSS ellipsis then absorbs
+ * whatever still does not fit the rendered width.
+ */
+const MAX_DISPLAY_PATH_LENGTH = 40;
+
+/**
+ * Get the workspace-relative folder holding a query document.
+ * @param queryState The query execution state of a history entry.
+ * @returns The folder path, an empty string for the workspace root, or `undefined` when the
+ * query is not backed by a workspace file (e.g. an untitled editor).
+ */
+function getWorkspaceFolder(queryState: SparqlQueryExecutionState): string | undefined {
+	return queryState.workspaceIri ? getFolderPath(queryState.workspaceIri) : undefined;
+}
+
+/**
+ * Get the folder label shown beside a query's file name.
+ * @param folder A workspace-relative folder path, empty for the workspace root.
+ * @returns `~` for the workspace root, otherwise the folder shortened from the start so its
+ * most specific segments stay readable in the narrow column.
+ */
+function getFolderLabel(folder: string): string {
+	return folder.length > 0 ? `~/${shortenPathStart(folder, MAX_DISPLAY_PATH_LENGTH)}` : '~';
+}
+
+/**
+ * Get the tooltip of a query row, showing the untruncated workspace-relative location of the
+ * document so the full path stays reachable once the label or the folder has been shortened.
+ * @param folder The workspace-relative folder, empty for the workspace root, or `undefined`
+ * when the query is not backed by a workspace file.
+ * @param displayName The row's visible label.
+ * @returns The `~`-prefixed workspace path of the document, falling back to the display name
+ * for queries without a workspace file.
+ */
+function getRowTooltip(folder: string | undefined, displayName: string): string {
+	if (folder === undefined) {
+		return displayName;
+	}
+
+	return folder.length > 0 ? `~/${folder}/${displayName}` : `~/${displayName}`;
+}
 
 /**
  * The Recent Queries column of the SPARQL results welcome view: lists the
@@ -32,14 +76,6 @@ export function SparqlRecentQueryList() {
 
 	const loadHistory = () => {
 		messaging?.postMessage({ id: 'GetSparqlQueryHistory' });
-	};
-
-	const getWorkspacePath = (queryState: SparqlQueryExecutionState): string | undefined => {
-		if (queryState.workspaceIri) {
-			const folderPath = getPath(toDisplayPath(queryState.workspaceIri));
-
-			return folderPath.length > 0 ? `~${folderPath}` : '~';
-		}
 	};
 
 	const handleClearHistory = () => {
@@ -86,24 +122,34 @@ export function SparqlRecentQueryList() {
 			</div>
 			<div className="body button-list">
 				{history.length === 0 && <span className="muted">No recent queries in this workspace.</span>}
-				{history.length > 0 && history.map((queryState, index) => (
-					<div key={`${queryState.documentIri}-${index}`} className="history-item">
-						<img className="file-icon file-icon-dark" src={sparqlFileIconDark} alt="" />
-						<img className="file-icon file-icon-light" src={sparqlFileIconLight} alt="" />
-						<a className="file-link" onClick={() => handleOpenDocument(queryState)}>
-							<span>{getDisplayName(queryState)}</span>
-						</a>
-						<span className="folder muted">{getWorkspacePath(queryState)}</span>
-						<span className="actions">
-							<a className='execute-button codicon codicon-play' role="button" title="Run"
-								onClick={() => handleExecuteQuery(queryState)}>
+				{history.length > 0 && history.map((queryState, index) => {
+					const displayName = getDisplayName(queryState);
+					const workspaceFolder = getWorkspaceFolder(queryState);
+					const tooltip = getRowTooltip(workspaceFolder, displayName);
+
+					return (
+						<div key={`${queryState.documentIri}-${index}`} className="history-item">
+							<img className="file-icon file-icon-dark" src={sparqlFileIconDark} alt="" />
+							<img className="file-icon file-icon-light" src={sparqlFileIconLight} alt="" />
+							<a className="file-link" title={tooltip} onClick={() => handleOpenDocument(queryState)}>
+								<span>{displayName}</span>
 							</a>
-							<a className="remove-button codicon codicon-close" role="button" title="Remove"
-								onClick={() => handleRemoveFromHistory(queryState)}>
-							</a>
-						</span>
-					</div>
-				))}
+							{workspaceFolder !== undefined && (
+								<span className="folder folder-path muted" title={tooltip}>
+									{getFolderLabel(workspaceFolder)}
+								</span>
+							)}
+							<span className="actions">
+								<a className='execute-button codicon codicon-play' role="button" title="Run"
+									onClick={() => handleExecuteQuery(queryState)}>
+								</a>
+								<a className="remove-button codicon codicon-close" role="button" title="Remove"
+									onClick={() => handleRemoveFromHistory(queryState)}>
+								</a>
+							</span>
+						</div>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
+++ b/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
@@ -82,7 +82,10 @@
 	font-size: large;
 }
 
-.sparql-welcome-view-container .column .body.button-list .codicon-arrow-swap {
+/* The resting colour of a connection icon. Excluding the status classes keeps this
+   four-class selector from outweighing the two-class status tints below, which would
+   otherwise leave a tested connection's icon stuck at its resting colour. */
+.sparql-welcome-view-container .column .body.button-list .codicon-arrow-swap:not(.connection-status-pass):not(.connection-status-error) {
 	color: var(--vscode-symbolIcon-enumeratorMemberForeground);
 }
 

--- a/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
+++ b/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
@@ -10,12 +10,15 @@
 	left: 0;
 }
 
+/* auto-fit tracks let the columns sit side by side while both fit the panel width and
+   stack once they no longer do, so a narrow panel never scrolls horizontally. */
 .sparql-welcome-view-container {
-	display: flex;
-	flex-direction: row;
-	gap: 60px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+	align-items: start;
+	gap: var(--mentor-space-7) 60px;
 	padding: 20px;
-	min-width: 1000px;
+	box-sizing: border-box;
 }
 
 .sparql-welcome-view-container .muted {
@@ -28,8 +31,7 @@
 }
 
 .sparql-welcome-view-container .column-wide {
-	min-width: 360px;
-	max-width: 460px;
+	min-width: 0;
 }
 
 .sparql-welcome-view-container .column .header {
@@ -74,13 +76,20 @@
 }
 
 .sparql-welcome-view-container .history-item {
-    display: flex;
-    align-items: center;
-	gap: 4px;
-    padding: 2px;
-	border-radius: 3px;
+	display: flex;
+	align-items: center;
+	flex-wrap: nowrap;
+	gap: var(--mentor-space-2);
+	padding: 2px;
+	border-radius: var(--mentor-radius-md);
 	width: 100%;
-    margin-bottom: 2px;
+	min-width: 0;
+	margin-bottom: 2px;
+}
+
+/* Leading status icons keep their size; only the text of a row gives way. */
+.sparql-welcome-view-container .history-item > .codicon {
+	flex-shrink: 0;
 }
 
 .sparql-welcome-view-container .history-item:hover,
@@ -103,13 +112,30 @@
 }
 
 .sparql-welcome-view-container .folder {
-	margin-left: 7px;
+	flex: 0 0 auto;
+	min-width: 0;
+	margin-left: var(--mentor-space-3);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* A query's workspace path absorbs the row's slack and is the first text to give way,
+   since it is already shortened from the start and carries its full value in a tooltip. */
+.sparql-welcome-view-container .folder-path {
+	flex: 1 1 auto;
+	flex-shrink: 3;
 }
 
 .sparql-welcome-view-container .file-link {
 	color: var(--vscode-textLink-foreground) !important;
-    text-decoration: none;
-    cursor: pointer;
+	text-decoration: none;
+	cursor: pointer;
+	flex: 0 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .sparql-welcome-view-container .execute-button {
@@ -120,9 +146,11 @@
 
 .sparql-welcome-view-container .actions {
 	margin-left: auto;
+	flex-shrink: 0;
 	display: flex;
 	flex-direction: row;
 	gap: var(--mentor-space-3);
+	padding-left: var(--mentor-space-3);
 }
 
 .sparql-welcome-view-container .file-icon {

--- a/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
+++ b/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
@@ -10,13 +10,14 @@
 	left: 0;
 }
 
-/* auto-fit tracks let the columns sit side by side while both fit the panel width and
-   stack once they no longer do, so a narrow panel never scrolls horizontally. */
+/* The columns wrap onto their own row once they no longer fit side by side, so a narrow
+   panel never scrolls horizontally. They pack to the left rather than dividing the panel
+   between them, which would strand each column's actions at its far edge. */
 .sparql-welcome-view-container {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-	align-items: start;
-	gap: var(--mentor-space-7) 60px;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: var(--mentor-space-7) 40px;
 	padding: 20px;
 	box-sizing: border-box;
 }
@@ -30,8 +31,22 @@
 	text-decoration: underline;
 }
 
-.sparql-welcome-view-container .column-wide {
+/* Sized to its own content rather than to an equal share of the panel, so it does not
+   stretch far past the endpoint URLs it holds. Shrinks below that when space is tight and
+   truncates once it reaches the upper bound. */
+.sparql-welcome-view-container .column-auto {
+	flex: 0 1 auto;
 	min-width: 0;
+	max-width: 480px;
+}
+
+/* Absorbs the width the content-sized columns leave over, since its rows carry the most
+   text (a file name and a path). The upper bound stops a row's actions from drifting to
+   the far edge of a wide panel. */
+.sparql-welcome-view-container .column-grow {
+	flex: 1 1 360px;
+	min-width: 0;
+	max-width: 560px;
 }
 
 .sparql-welcome-view-container .column .header {

--- a/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
+++ b/src/views/webviews/views/sparql-results/components/sparql-welcome-view.css
@@ -37,7 +37,7 @@
 .sparql-welcome-view-container .column-auto {
 	flex: 0 1 auto;
 	min-width: 0;
-	max-width: 480px;
+	max-width: 520px;
 }
 
 /* Absorbs the width the content-sized columns leave over, since its rows carry the most
@@ -85,6 +85,7 @@
 /* The resting colour of a connection icon. Excluding the status classes keeps this
    four-class selector from outweighing the two-class status tints below, which would
    otherwise leave a tested connection's icon stuck at its resting colour. */
+.sparql-welcome-view-container .column .body.button-list .codicon-sync,
 .sparql-welcome-view-container .column .body.button-list .codicon-arrow-swap:not(.connection-status-pass):not(.connection-status-error) {
 	color: var(--vscode-symbolIcon-enumeratorMemberForeground);
 }
@@ -183,6 +184,12 @@ body.vscode-dark .sparql-welcome-view-container .file-icon-light,
 body.vscode-high-contrast:not(.vscode-high-contrast-light) .sparql-welcome-view-container .file-icon-light,
 body.vscode-high-contrast-light .sparql-welcome-view-container .file-icon-dark {
 	display: none;
+}
+
+/* Separates the segments of a row's details text. Dimmed so it reads as punctuation
+   rather than as a value of its own. */
+.sparql-welcome-view-container .detail-separator {
+	opacity: 0.5;
 }
 
 .sparql-welcome-view-container .connection-status-pass {

--- a/src/views/webviews/views/sparql-results/components/sparql-welcome-view.tsx
+++ b/src/views/webviews/views/sparql-results/components/sparql-welcome-view.tsx
@@ -1,7 +1,7 @@
 import { useStylesheet } from '@src/views/webviews/hooks';
 import { useSharedStylesheets } from '@src/views/webviews/hooks/use-shared-stylesheets';
-import { SparqlRecentQueryList } from './sparql-recent-query-list';
 import { SparqlConnectionsList } from './sparql-connections-list';
+import { SparqlRecentQueryList } from './sparql-recent-query-list';
 import stylesheet from './sparql-welcome-view.css';
 
 /**
@@ -14,8 +14,8 @@ export function SparqlWelcomeView() {
 	return (
 		<vscode-scrollable>
 			<div className="sparql-welcome-view-container">
-				<SparqlRecentQueryList />
 				<SparqlConnectionsList />
+				<SparqlRecentQueryList />
 			</div>
 		</vscode-scrollable>
 	);


### PR DESCRIPTION
Fixes #81.

## Problem

Rows in the SPARQL welcome view wrapped onto a second line whenever a query's workspace path was long enough, knocking the rest of the list out of alignment. `.history-item` is a flex row whose text children carried no `min-width: 0`, `white-space: nowrap` or `text-overflow: ellipsis`, inside a column hard-capped at `max-width: 460px`.

The cap was half of a container that fought itself: `min-width: 1000px` forced the whole view to scroll horizontally in a normal panel, while `max-width: 460px` stopped a column from ever using a wide monitor. The wrap was the symptom; that pair was the cause.

Both columns share the row stylesheet, so the Connections column had the same bug — and it is where it hurt most: `Error loading graphs` was squeezed into a 46px box and wrapped, and the error icon beside it shrank from 16px to 8px, both inheriting `flex-shrink: 1` from the row.

## Changes

**`sparql-welcome-view.css` — rows are single-line by construction**

- `.file-link` (file name / endpoint URL) and `.folder` (path / details) get the truncation idiom already used in `validation.css`. `.actions` and the leading `.codicon` status icons get `flex-shrink: 0`, so only text gives way.
- `.folder-path` — a query's path — gets `flex-shrink: 3`, so it yields before the file name does. It is already shortened and carries its full value in a tooltip, which recent-query rows previously lacked entirely.
- `.folder` alone stays `flex: 0 0 auto`: the connection details (`312 graphs`) are short and meaningful and must not be truncated.
- The container becomes a wrapping flex row whose columns **pack to the left** rather than dividing the panel between them, which stranded each column's actions at its far edge. Column gap 60px → 40px.
- The two columns now size to what they hold: `.column-auto` (Connections) takes only the width its endpoint URLs need; `.column-grow` (Recent Queries) absorbs what is left, since its rows carry both a file name and a path. Both keep an upper bound so actions stay beside their text on a wide monitor.
- The resting colour of `.codicon-arrow-swap` is scoped with `:not(.connection-status-pass):not(.connection-status-error)`. At four classes it outweighed the two-class status tints, which is why the green success tint had never appeared; excluding the status classes lets both tints through without escalating specificity further.
- New `.detail-separator`, dimmed to `opacity: 0.5` so the dot reads as punctuation rather than a value.

**`utilities/uri.ts` — two new helpers**

- `getFolderPath()` returns the folder of a URI, or `''` when there is none — so callers can distinguish "no folder" from "a folder named like a file", and it decodes exactly once. `getPath()` is deliberately left alone: five other call sites depend on its current contract.
- `shortenPathStart()` shortens a path from the *start*, dropping whole segments and marking them with an ellipsis, so the most specific trailing segments survive. CSS `text-overflow` keeps the head and discards the tail, which is the less useful half for a path. Preferred over the `direction: rtl` trick, which is fragile around the `~` prefix and the slashes, and is not testable.

**`sparql-recent-query-list.tsx`**

- Replaces `getWorkspacePath()`, which did `getPath(toDisplayPath(iri))`. That decoded percent escapes twice — harmless for ordinary paths, but an uncaught `URIError: URI malformed` for a folder such as `100% done`, which crashed the whole list render:

  ```
  workspace:///100%25%20done/file.rq   ->   URIError: URI malformed
  workspace:///census.rq              ->   "~census.rq"    (a file name as a folder)
  ```

  Both are fixed: a root-level query now renders `~`, and the `~` gains its separator (`~/queries/dbpedia`).
- Adds a row tooltip carrying the untruncated `~/folder/file.rq`, on both the name and the path.

**`sparql-connections-list.tsx`**

- The circled-x is gone; a failed test now tints the connection icon red, so a row reports its state in one place. The failure message moves to that icon's tooltip, which previously populated only on *success* — so the one element a user is likely to hover said nothing when it mattered.
- The details text now leads with the test outcome — `Connected` or `Connection failed` — ahead of the graph count, separated by the `' · '` the extension already uses between segments in `sparql-status-bar-service.ts` and `manage-shacl-shapes.ts`. Both read muted; the icon tint carries the severity.
- The details text is composed of segments rather than one string, so a graph-loading error keeps its own error colour and each segment keeps its own tooltip. The status segment repeats the failure message, giving it a word-sized hover target instead of a single glyph.

**`sparql-welcome-view.tsx`** — swaps the column order to put Connections before Recent Queries.

## Tests

13 added to `uri.test.ts` for the two new helpers, including the two defects above (`getFolderPath` on a root-level file and on a literal `%` escape) and a loop asserting `shortenPathStart` never exceeds its budget at any length.

No test previously covered the welcome view, and none is added here: the change is layout, which a jsdom-less `environment: 'node'` suite cannot assert. It was verified by measurement instead — see below.

## Verification

`npx tsc --noEmit` clean · `npx eslint src` clean · `node build.js` clean · `npx vitest run` — **2982 passed (237 files)**

Layout measured in Chromium against the real stylesheet, comparing `main` to this branch. Row heights in px, one row per query:

```
BEFORE @ 1400px  heights=[20,20,20,20,34]  wrappedRows=1  hScroll=false
BEFORE @  700px  heights=[20,20,20,20,34]  wrappedRows=1  hScroll=true
AFTER  @ 1400px  heights=[20,20,20,20,20]  wrappedRows=0  hScroll=false
AFTER  @  400px  heights=[20,20,20,20,20]  wrappedRows=0  hScroll=false  stacked=true
```

Rows hold at one line down to 240px even with a 73-character file name. Below 320px the view scrolls horizontally rather than truncating everything into uselessness.

Column sizing, and the empty space between a Connections row's text and its actions:

```
BEFORE @ 1920px  colWidths=[940,940]  deadSpaceAfterText=681px
BEFORE @ 1400px  colWidths=[680,680]  deadSpaceAfterText=421px
AFTER  @ 1920px  colWidths=[292,560]  deadSpaceAfterText= 33px
AFTER  @  700px  colWidths=[292,368]  deadSpaceAfterText= 33px
```

All ten combinations of test outcome and graph state, checking rendered text, computed colour per segment, tooltips and row height:

```
untested, graphs known  icon=blue   "312 graphs"                          (grey)
success + graphs        icon=green  "Connected · 312 graphs"              (grey, grey)
failed + graphs         icon=RED    "Connection failed · 312 graphs"      (grey, grey)
success + load error    icon=green  "Connected · Error loading graphs"    (grey, RED)
failed + load error     icon=RED    "Connection failed · Error loading…"  (grey, RED)
failed, no graphs       icon=RED    "Connection failed"                   (grey)
loading graphs          icon=green  "Connected · Loading…"                (grey, grey)
```

Every row stays 24px, nothing truncates at the resulting column width, and the failure tooltip reads `Connection test failed: HTTP 503 Service Unavailable`.

## Open questions

- **"Connection failed" is rendered grey, not red**, with the icon tint carrying severity. One-line change if the word should be red too.
- **Untested connections get no label** — just the graph count, as before. Every connection would otherwise carry an `Untested` badge on startup.
- **The graph-load error does not tint the icon**, only the test failure does; the load error already shows as red text with its own tooltip.
- **The upper bounds (520px / 560px)** are the judgement call in the column sizing — the numbers to raise if the lists should keep growing on a large screen.
- **When the panel is narrow enough to stack**, the content-sized Connections column keeps its content width rather than filling the row, so the stacked layout is slightly ragged. Inherent to `flex-grow: 0`; needs a media query to switch the grow factor if that matters.

## Not changed

Four dead selectors in `sparql-welcome-view.css` — three `.body.button-list vscode-toolbar-button` rules and `.button-list-xl`. The toolbar buttons live in `.header`, not `.body`, so none of them can match. Left for a separate tidy to keep this diff reviewable.

The in-memory query history the webview renders is uncapped within a session, though the persisted history is capped at 10 (`sparql-query-service.ts:40`). Rows are now dense enough that this is not pressing; grouping by folder with a filter box is the answer if long sessions become a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
